### PR TITLE
Update README.md

### DIFF
--- a/Code/26_Buildroot/README.md
+++ b/Code/26_Buildroot/README.md
@@ -85,7 +85,17 @@ cd ..
 make xconfig
 ```
 
-para abrir a interface gráfica de personalização da ompilação do sistema operacional. Marque as seguintes opções:
+para abrir a interface gráfica de personalização da ompilação do sistema operacional. 
+Obs.: Se no seu terminal der algum erro e aparecer
+
+```
+* Could not find Qt via pkg-config.
+* Please install either Qt 4.8 or 5.x. and make sure it's in PKG_CONFIG_PATH
+```
+
+Use `menuconfig` ao invés do `xconfig`
+
+Marque as seguintes opções:
 
 * `System Configuration ==> Run a getty (login prompt) after boot`
 * `Target packages ==> Miscellaneous ==> hello_buildroot`


### PR DESCRIPTION
No meu ubuntu tive problemas em usar o xconfig, segundo a documentação do buildroot era um problema de dependências:

For these libraries, you need to install both runtime and development data, which in many distributions are packaged separately. The development packages typically have a -dev or -devel suffix.

    ncurses5 to use the menuconfig interface
    qt5 to use the xconfig interface
    glib2, gtk2 and glade2 to use the gconfig interface 

O menuconfig foi o único que funcionou, então adicionei uma observação pra caso alguém tenha o mesmo problema que eu tive.