### PR TITLE
Correção do exemplo de sockets

### DIFF
--- a/2_Programação_sistemas_operacionais/2.7_Sockets/server_funcs.c
+++ b/2_Programação_sistemas_operacionais/2.7_Sockets/server_funcs.c
@@ -1,5 +1,8 @@
 #include "server_funcs.h"
 
+char socket_name[100];
+int socket_id;
+
 int print_client_message(int client_socket)
 {
 	int length, end_server_ok;

--- a/2_Programação_sistemas_operacionais/2.7_Sockets/server_funcs.h
+++ b/2_Programação_sistemas_operacionais/2.7_Sockets/server_funcs.h
@@ -10,8 +10,8 @@
 #include <sys/un.h>
 #include <arpa/inet.h>
 
-char socket_name[100];
-int  socket_id;
+extern char socket_name[100];
+extern int  socket_id;
 int  print_client_message(int client_socket);
 void end_server(int signum);
 


### PR DESCRIPTION
Os exemplos de cliente e servidor locais não estavam compilando por conta do cabeçalho **server_func.h**, pois os arquivos **.o** gerados por arquivos que io incluíam estavam fazendo também uma definição das variáveis **socket_name** e **socket_id**.

O problema foi corrigido modificando o arquivo **server_func.h** para conter apenas a declaração das variáveis:
```c
#ifndef SERVER_FUNCS_H
#define SERVER_FUNCS_H
// --snip--
extern char socket_name[100];
extern int  socket_id;
// --snip--
#endif // SERVER_FUNCS_H
```
E fazendo a definição delas no arquivo **server_func.c**:

```c
#include "server_funcs.h"

char socket_name[100];
int socket_id;

int print_client_message(int client_socket)
{
	// --snip--
}
void end_server(int signum)
{
	// --snip--
}
```
Dessa maneira não há conflito de definição na hora de linkar os arquivos **.o** e todo código que incluir o cabeçalho **server_func.h** compartilhará normalmente da definição contida no object file **server_func.o**.

Todos os outros exemplos da seção foram compilados com sucesso.

Compilador: **gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0**
Make: **GNU Make 4.3            Built for x86_64-pc-linux-gnu**